### PR TITLE
Fix: Pass changeresolution boolean to Patch method

### DIFF
--- a/Classes/Game.cs
+++ b/Classes/Game.cs
@@ -41,7 +41,7 @@ namespace SCVRPatcher {
                     continue;
                 }
                 var attributes = new AttributesFile(attributesFile);
-                if (!attributes.Patch(config, resolution)) {
+                if (!attributes.Patch(config, resolution, changeresolution)) {
                     Logger.Error($"Failed to patch {attributesFile.Quote()}!");
                     continue;
                 }

--- a/Classes/Xml/AttributesFile.cs
+++ b/Classes/Xml/AttributesFile.cs
@@ -107,14 +107,15 @@ namespace SCVRPatcher {
                 Logger.Info($"Set attribute: {item.Key} to {item.Value}");
             }
             if (config.Fov is not null) changed |= AddOrUpdate("FOV", config.Fov);
-            // TODO: Add a way to change resolution based on if user checks a checkbox, see below
-            // I'm not able to figure out how to get the 'isChecked' to work here....
 
             if (changeresolution) {
             Logger.Info("Changing resolution to match HMD");
                 if (resolution.Height is not null) changed |= AddOrUpdate("Height", resolution.Height);
                 if (resolution.Width is not null) changed |= AddOrUpdate("Width", resolution.Width);
                 Logger.Info($"Changed resolution to {resolution.Width}x{resolution.Height}");
+            }
+            else {
+                Logger.Info("Not changing game resolution to match headset as requested");
             }
             if (changed) {
                 Save();


### PR DESCRIPTION
- Updated Game.cs to call the correct overloaded Patch method with the changeresolution boolean.
- Removed outdated TODO comment in AttributesFile.cs regarding the changeresolution checkbox.
- Added logging in AttributesFile.cs to indicate whether the resolution is being changed based on the changeresolution flag.

These changes ensure that the checkbox state for changing resolution is correctly passed and handled, resulting in the appropriate behavior based on user input.

Issue #8 